### PR TITLE
Generic Commandline Passthru - specify any ganache-cli settings as options to solidity-shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes will be documented in this file.
 
+## v0.0.8
+- new: Passthru ganache-cli settings as options to solidity-shell #7
+```shell
+⇒ solidity-shell -- -fork https://mainnet.infura.io/v3/yourToken
+```
+- fix: `.config set` handling of strings and multi-word arguments
 
 ## v0.0.7
 - fix: rework remote compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes will be documented in this file.
 ## v0.0.8
 - new: Passthru ganache-cli settings as options to solidity-shell #7
 ```shell
-⇒ solidity-shell -- -fork https://mainnet.infura.io/v3/yourToken
+solidity-shell -- -fork https://mainnet.infura.io/v3/yourToken
+```
+
+Query a live contracts `ERC20.name()`:
+```solidity
+
+ »  interface ERC20 {
+multi> function name() external view returns (string memory);
+multi> }
+ 
+ »  ERC20(0xB8c77482e45F1F44dE1745F52C74426C631bDD52).name()
+BNB
+
 ```
 - fix: `.config set` handling of strings and multi-word arguments
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ An interactive Solidity shell with lightweight session recording and remote comp
 352
 ```
 
-Oh, did you know that we automatically fetch a matching remote compiler when you change the solidity pragma? It is as easy as typing `pgrama solidity 0.5.0` and solidity-shell will do the rest 🙌
+Oh, did you know that we automatically fetch a matching remote compiler when you change the solidity pragma? It is as easy as typing `pgrama solidity 0.5.0` and solidity-shell will do the rest 🙌.
+
+
 
 ### Hints
-
-
 
 * `pragma solidity <version>` attempts to dynamically load the selected compiler version (remote compiler, may take a couple of seconds).
 * Sessions can be saved and restored using the `.session` command. Your previous session is always stored and can be loaded via `.session load previous` (not safe when running concurrent shells).
@@ -41,7 +41,18 @@ Oh, did you know that we automatically fetch a matching remote compiler when you
 * `$_` is a placeholder for the last known result. Feel free to use that placeholder in your scripts :)
 * Special commands are dot-prefixed. Everything else is evaluated as Solidity code.
 
+
 ### Usage
+
+#### Cmdline Passthru
+
+Any arguments provided after an empty `--` are directly passed to `ganacheCmd` (default: `ganache-cli`). This way, for example, you can start a solidity shell on a ganache fork of mainnet via infura. Check `ganache-cli --help` for a list of available options.
+
+```shell
+⇒  solidity-shell -- --fork https://mainnet.infura.io/v3/yourApiToken
+```
+
+#### Repl
 
 ```shell
  🚀 Entering interactive Solidity shell. '.help' and '.exit' are your friends.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "solidity-shell",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solidity-shell",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
+        "minimist": "^1.2.5",
         "readline-sync": "^1.4.10",
         "request": "^2.88.2",
         "solc": "^0.8.10",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "minimist": "^1.2.5",
     "readline-sync": "^1.4.10",
     "request": "^2.88.2",
     "solc": "^0.8.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-shell",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "src/index.js",
   "bin": {

--- a/src/handler.js
+++ b/src/handler.js
@@ -113,6 +113,7 @@ class InteractiveSolidityShell {
 
     constructor(settings, log) {
         this.log = log || console.log;
+
         const defaults = {
             templateContractName: 'MainContract',
             templateFuncMain: 'main',
@@ -120,6 +121,7 @@ class InteractiveSolidityShell {
             providerUrl: 'http://localhost:8545',
             autostartGanache: true,
             ganacheCmd: 'ganache-cli',
+            ganacheArgs: [],
             debugShowContract: false
         }
 
@@ -153,7 +155,19 @@ class InteractiveSolidityShell {
     }
 
     setSetting(key, value){
-        if(key === 'installedSolidityVersion') return;
+        switch(key){
+            case 'installedSolidityVersion': return;
+            case 'ganacheArgs':
+                if(!value) {
+                    value = [];
+                }
+                else if(!Array.isArray(value)){
+                    value = value.split(' ');
+                }
+                break;
+            case 'ganacheCmd':
+                value = value.trim();
+        }
         this.settings[key] = value;
     }
 
@@ -395,7 +409,7 @@ class Blockchain {
         if (this.proc) {
             return this.proc;
         }
-        this.proc = require('child_process').spawn(this.settings.ganacheCmd);
+        this.proc = require('child_process').spawn(this.settings.ganacheCmd, this.settings.ganacheArgs);
     }
 
     stopService() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,8 @@ function convert(str){
         case 'false': return false;
     }
     try {
-        return parseInt(str);
+        let num = parseInt(str);
+        if(!isNaN(num)) return num;
     } catch {}
 
     return str;
@@ -32,8 +33,6 @@ function multilineInput(command){
     }
     return command;
 }
-
-
 
 module.exports = {
     convert,


### PR DESCRIPTION
* fix issue when setting string settings via `.config set`
* allow custom cmdline args to `ganache-cli` via cmdline passthru.

e.g. start on a ganache-cli fork of mainnet at the current tip.
```shell
solidity-shell -- -fork https://mainnet.infura.io/v3/yourToken
```

pretty cool, allows you to do this:

```solidity

 »  interface ERC20 {
multi> function name() external view returns (string memory);
multi> }
 
 »  ERC20(0xB8c77482e45F1F44dE1745F52C74426C631bDD52).name()
BNB

```